### PR TITLE
fix: Permitir validação de convite independente do status inicial

### DIFF
--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -28,10 +28,10 @@ const Invite = () => {
       try {
         // Buscar convite na tabela brand_invites
         const { data, error: fetchError } = await supabase
-          .from('brand_invites')
-          .select('*')
-          .eq('invite_code', code)
-          .eq('status', 'pending')
+          .from("brand_invites")
+          .select("*")
+          .eq("invite_code", code)
+          // .eq("status", "pending")
           .single();
 
         if (fetchError || !data) {
@@ -66,13 +66,13 @@ const Invite = () => {
     const checkProfile = async () => {
       if (user && !validating && inviteValid) {
         const { data: profile } = await supabase
-          .from('profiles')
-          .select('*')
-          .eq('user_id', user.id)
+          .from("profiles")
+          .select("*")
+          .eq("user_id", user.id)
           .maybeSingle();
 
         if (profile) {
-          navigate('/dashboard');
+          navigate("/dashboard");
         }
       }
     };
@@ -145,7 +145,7 @@ const Invite = () => {
                 </Alert>
                 <div className="flex gap-2">
                   <button
-                    onClick={() => navigate('/auth')}
+                    onClick={() => navigate("/auth")}
                     className="flex-1 px-4 py-2 bg-terracotta hover:bg-dark-terracotta text-white rounded-lg"
                   >
                     Criar Conta / Login
@@ -174,7 +174,7 @@ const Invite = () => {
             </Alert>
           </div>
           <BrandRegistration 
-            onBack={() => navigate('/')} 
+            onBack={() => navigate("/")} 
             inviteCode={code}
             inviteData={inviteData}
           />
@@ -185,3 +185,4 @@ const Invite = () => {
 };
 
 export default Invite;
+


### PR DESCRIPTION
Esta correção comenta a condição  na busca do convite em . Isso permite que o convite seja validado independentemente do seu status inicial, resolvendo o problema de 'Convite não encontrado ou já foi utilizado' ao tentar usar um link gerado. A lógica para atualizar o status do convite para 'used' após o registro da marca ainda precisará ser implementada separadamente para garantir a integridade do sistema.